### PR TITLE
Add repo selection and PR list display vuyage 15 and 16

### DIFF
--- a/client/app/open-prs/page.tsx
+++ b/client/app/open-prs/page.tsx
@@ -1,0 +1,133 @@
+"use client";
+
+import { useState } from "react";
+import type { PullRequest } from "@/types/pt";
+import PullRequestCard from "@/components/OpenPRCard";
+
+export default function OpenPRsPage() {
+    const [prs, setPrs] = useState<PullRequest[]>([]);
+    const [error, setError] = useState("");
+
+    // Default value to test (owner and repo name)
+    const [owner, setOwner] = useState("chingu-voyages");
+    const [repo, setRepo] = useState("V57-tier3-team-39");
+    const [token, setToken] = useState("");
+
+    const isDisabled = !owner || !repo;
+
+
+    const fetchPRs = async () => {
+        setError("");
+        try {
+            const res = await fetch(
+            `https://api.github.com/repos/${owner}/${repo}/pulls?state=open`,
+                token
+                ? { headers: { Authorization: `token ${token}` } }
+                : undefined
+            );
+
+            if (!res.ok) {
+                throw new Error("Invalid repository name");
+            }
+            const data = await res.json();
+            const mapped: PullRequest[] = data.map((pr: any) => ({
+                number: pr.number,
+                title: pr.title,
+                author: pr.user?.login ?? "Unknown",
+                createdAt: pr.created_at,
+                updatedAt: pr.updated_at,
+                requested_reviewers: pr.requested_reviewers?.map((r: any) => r.login) ?? [],
+                lastAction: pr.state,
+            }));
+
+            setPrs(mapped);
+        } catch (err: any) {
+            setError(err.message);
+            setPrs([]);
+        }
+    };
+
+    return (
+    <>
+        <div className="p-3 text-4xl font-bold">Open Pull Requests</div>
+
+        <div className="p-3 text-gray-600">
+        Track and manage currently open pull requests awaiting review
+        </div>
+
+        <div className="mt-8 mx-4 p-6 shadow-lg rounded-lg bg-white">
+            <h2 className="text-xl font-bold mb-4">Repository Settings</h2>
+
+            <div className="flex flex-col sm:flex-row gap-4">
+                <div className="flex-1">
+                    <label className="block text-sm font-medium mb-1">
+                        Repository Owner
+                    </label>
+                    <input
+                        type="text"
+                        value={owner}
+                        onChange={(e) => setOwner(e.target.value)}
+                        placeholder="e.g... facebook"
+                        className="w-full border border-gray-300 px-3 py-2 rounded-md"
+                    />
+                </div>
+
+                <div className="flex-1">
+                    <label className="block text-sm font-medium mb-1">
+                        Repository Name
+                    </label>
+                    <input
+                        type="text"
+                        value={repo}
+                        onChange={(e) => setRepo(e.target.value)}
+                        placeholder="e.g... react"
+                        className="w-full border border-gray-300 px-3 py-2 rounded-md"
+                    />
+                </div>
+            </div>
+
+            <div className="mt-4">
+                <label className="block text-sm font-medium mb-1">
+                GitHub Personal Access Token (Optional)
+                </label>
+                <input
+                type="password"
+                value={token}
+                onChange={(e) => setToken(e.target.value)}
+                placeholder="ghp_..."
+                className="w-full border border-gray-300 px-3 py-2 rounded-md"
+                />
+            </div>
+
+            <div className="mt-6 flex flex-col sm:flex-row gap-3">
+                <button
+                    onClick={fetchPRs}
+                    disabled={isDisabled}
+                    className={`px-4 py-2 rounded-md text-white ${
+                    isDisabled
+                        ? "bg-blue-300 cursor-not-allowed"
+                        : "bg-blue-600 hover:bg-blue-700"
+                    }`}
+                >
+                    Fetch Pull Requests
+                </button>
+            </div>
+        </div>
+
+        {/* Display fetch data */}
+        <div className="m-8 mx-4 p-6 bg-gray-50 border border-gray-300 rounded-md">
+                {error && (
+                    <div className="flex justify-center items-center h-32">
+                        <p className="text-red-500 text-2xl">{error}</p>
+                    </div>
+                )}
+
+                {prs.length === 0 && !error ? (
+                    <div className="text-gray-600 text-2xl">No open PRs</div>
+                ) : (
+                    prs.map((pr) => <PullRequestCard key={pr.number} pr={pr} />)
+                )}
+            </div>
+    </>
+    );
+}

--- a/client/app/page.tsx
+++ b/client/app/page.tsx
@@ -6,8 +6,15 @@ import {
   IconCircleCheckFilled,
   IconClockFilled,
 } from "@tabler/icons-react";
+import { useRouter } from "next/navigation";
 
 export default function Home() {
+  const router = useRouter();
+
+  const handlePRpage = () => {
+    router.push("/open-prs");
+  }
+
   return (
     <div className="flex justify-items-center min-h-screen p-8 pb-20 gap-16 sm:p-20">
       <main className="flex flex-col gap-[32px] row-start-2 items-center sm:items-start">
@@ -21,7 +28,7 @@ export default function Home() {
             in one beautiful dashboard.
           </p>
           <div className="flex gap-4 flex-col mt-4">
-            <Button variant="default">
+            <Button variant="default" onClick={handlePRpage}>
               View Open PRs
               <span>
                 <IconArrowRight size={18} />

--- a/client/components/OpenPRCard.tsx
+++ b/client/components/OpenPRCard.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { Card, Text } from "@mantine/core";
+import { PullRequest } from "@/types/pt";
+
+interface Props {
+    pr: PullRequest;
+}
+
+export default function PullRequestCard({ pr }: Props) {
+  return (
+    <Card shadow="sm" padding="lg" radius="md" withBorder className="mb-4">
+        <div className="flex flex-col md:flex-row md:justify-between md:items-center">
+            <div>
+                <Text fw={700} size="lg">
+                    <span className="bg-gray-200 px-1 rounded">#{pr.number}</span>{" "}
+                    <span className="text-blue-500">{pr.title}</span>
+                </Text>
+
+                <Text size="sm" c="dimmed">
+                    Opened by: {pr.author} on{" "}
+                    {new Date(pr.createdAt).toLocaleDateString("en-US", { month: "short", day: "numeric" })}
+                </Text>
+
+                <Text size="sm" c="dimmed">
+                    Last Action: {pr.lastAction} ()
+                </Text>
+            </div>
+
+            <Text size="sm" c="dimmed" className="mt-2 md:mt-0">
+                Reviewers: {pr.requested_reviewers.length > 0
+                ? pr.requested_reviewers.join(", ")
+                : "None"}
+            </Text>
+        </div>
+    </Card>
+  );
+}

--- a/client/types/pt.ts
+++ b/client/types/pt.ts
@@ -1,0 +1,9 @@
+export interface PullRequest {
+    number: number;
+    title: string;
+    author: string;
+    requested_reviewers: string[];
+    createdAt: string;
+    lastAction: string;
+    updatedAt: string;
+}


### PR DESCRIPTION
Summary

This PR implements the functionality for selecting a GitHub repository and displaying its open pull requests with detailed information. It combines the requirements from Voyage 15 and Voyage 16.

Features Implemented

1.Repository Selection (Voyage 15)
- Users can enter a Repository Owner and Repository Name
- A Fetch Pull Requests button is enabled only when both fields are filled
- Displays an error message if the repository is invalid

2.Open Pull Request List (Voyage 16)
- Displays each PR
- If no open PRs exist, displays a “No open PRs” message
- Each PR is displayed in a responsive card component using Mantine/Tailwind

Notes

- The lastAction field currently uses a placeholder value; fetching actual last actions will be implemented in a future update
- ypeScript types for PRs are defined in types/pr.ts
- UI components for PR cards are in components/PullRequestCard.tsx



<img width="1006" height="828" alt="Screenshot 2025-09-18 at 8 45 06 PM" src="https://github.com/user-attachments/assets/aa89c6a7-e133-486c-851a-6ae5b0254a85" />