### PR TITLE
Update PR cards layout according to wireframe

### DIFF
--- a/client/app/open-prs/page.tsx
+++ b/client/app/open-prs/page.tsx
@@ -4,18 +4,22 @@ import { useState } from "react";
 import type { PullRequest } from "@/types/pr";
 import PullRequestCard from "@/components/OpenPRCard";
 import { Box, Text } from "@mantine/core";
+import { BiSolidLeftArrow, BiSolidRightArrow } from "react-icons/bi";
 
 export default function OpenPRsPage() {
     const [prs, setPrs] = useState<PullRequest[]>([]);
     const [error, setError] = useState("");
-
     // Default value to test (owner and repo name)
     const [owner, setOwner] = useState("chingu-voyages");
     const [repo, setRepo] = useState("V57-tier3-team-39");
-
     const [token, setToken] = useState("");
+    const [page, setPage] = useState(1);
 
     const isDisabled = !owner || !repo;
+    const PAGE_SIZE = 3;
+    const totalPages = Math.max(1, Math.ceil(prs.length / PAGE_SIZE));
+    const paginatedPRs = prs.slice((page - 1) * PAGE_SIZE, page * PAGE_SIZE);
+
 
     const fetchPRs = async () => {
         setError("");
@@ -50,14 +54,10 @@ export default function OpenPRsPage() {
     };
 
   return (
-    <>
-        <div className="p-3 text-4xl font-bold">Open Pull Requests</div>
+    <div style={{ backgroundColor: "#F0E7FF"}}>
+        <div className="p-3 text-4xl font-bold text-center" style={{ color: "#2D3748"}}>Open Pull Requests</div>
 
-        <div className="p-3 text-gray-600">
-            Track and manage currently open pull requests awaiting review
-        </div>
-
-        <div className="mt-8 mx-4 p-6 shadow-lg rounded-lg bg-white">
+        <div className="mt-8 mx-4 p-6 shadow-lg rounded-lg bg-white lg:max-w-4xl lg:mx-auto">
             <h2 className="text-xl font-bold mb-4">Repository Settings</h2>
 
             <div className="flex flex-col sm:flex-row gap-4">
@@ -121,7 +121,7 @@ export default function OpenPRsPage() {
         </div>
 
         {/* Display fetch data */}
-        <div className="m-8 mx-4 p-1 border border-gray-300">
+        <div className="m-8 mx-4 p-1 border border-gray-300 bg-white lg:max-w-4xl lg:mx-auto">
             {error && (
                 <div className="flex justify-center items-center h-32">
                     <p className="text-red-500 text-2xl">{error}</p>
@@ -129,19 +129,46 @@ export default function OpenPRsPage() {
             )}
 
             {prs.length > 0 && (
-                <Box pl="md">
+                <div className="pl-6">
                     <Text size="xl" fw={700}>
                         PR Display
                     </Text>
-                </Box>
+                </div>
             )}
 
             {prs.length === 0 && !error ? (
                 <div className="text-gray-600 text-2xl">No open PRs</div>
             ) : (
-                prs.map((pr) => <PullRequestCard key={pr.number} pr={pr} />)
+                paginatedPRs.map((pr) => <PullRequestCard key={pr.number} pr={pr} />)
             )}
         </div>
-    </>
+
+        {prs.length > 1 && (
+            <div className="flex items-center justify-center gap-6 mb-8">
+                <button
+                    onClick={() => setPage((prev) => Math.max(prev - 1, 1))}
+                    disabled={page === 1}
+                    className={`py-2 ${page === 1 ? "opacity-50 cursor-not-allowed" : ""}`}
+                    style={{ color: "#805AD5", fontSize: "2rem" }}
+                >
+                    <BiSolidLeftArrow />
+                </button>
+
+                <span className="text-xl font-semibold" style={{ color: "#2D3748" }}>
+                    {page} / {totalPages}
+                </span>
+
+                <button
+                    onClick={() => setPage((prev) => Math.min(prev + 1, totalPages))}
+                    disabled={page === totalPages}
+                    className={`py-2 ${page === totalPages ? "opacity-50 cursor-not-allowed" : ""}`}
+                    style={{ color: "#805AD5", fontSize: "2rem" }}
+                >
+                    <BiSolidRightArrow />
+                </button>
+            </div>
+
+        )}
+    </div>
   );
 }

--- a/client/app/open-prs/page.tsx
+++ b/client/app/open-prs/page.tsx
@@ -54,7 +54,7 @@ export default function OpenPRsPage() {
     };
 
   return (
-    <div style={{ backgroundColor: "#F0E7FF"}}>
+    <div>
         <div className="p-3 text-4xl font-bold text-center" style={{ color: "#2D3748"}}>Open Pull Requests</div>
 
         <div className="mt-8 mx-4 p-6 shadow-lg rounded-lg bg-white lg:max-w-4xl lg:mx-auto">

--- a/client/components/OpenPRCard.tsx
+++ b/client/components/OpenPRCard.tsx
@@ -30,8 +30,49 @@ export default function PullRequestCard({ pr }: Props) {
         : created.toLocaleDateString("en-US", { month: "short", day: "numeric" });
 
     return (
-        <Card padding="lg" radius={0} className="mb-4 border-t-2 border-gray-400">
-            <div className="flex flex-col lg:grid lg:grid-cols-[1fr_0.5fr_2fr_2fr] lg:gap-2">
+        <Card padding="lg" radius={0} className="border-t-2 border-gray-400">
+            {/* Mobile design */}
+            <div>
+                <div className="flex flex-row items-center pb-2 lg:hidden">
+                    <Text fw={700} size="xl">
+                        <span className="px-2 py-1.5 rounded text-sm text-white shadow-md" style={{ backgroundColor: "#805AD5"}}>
+                        #{pr.number}
+                        </span>
+                    </Text>
+
+                    <div>{actionIcon()}</div>
+
+                    <Text fw={700}>
+                        <a 
+                            href={pr.url} 
+                            target="_blank" 
+                            rel="noopener noreferrer" 
+                            className="text-blue-600 hover:underline block truncate"
+                        >
+                            {pr.title}
+                        </a>
+                    </Text>
+                </div>
+
+                <div className="text-md lg:text-lg lg:hidden" style={{ color: "#2D3748"}}>
+                    Opened by: @{pr.author ?? "Unknown"} . {createdText}
+                </div>
+                
+                <div className="text-md lg:text-lg lg:hidden" style={{ color: "#2D3748"}}>
+                    Last Action: {pr.lastAction} ()
+                </div>
+
+                <div className="lg:justify-self-end lg:hidden" style={{ color: "#2D3748"}}>
+                    Reviewers:{" "}
+                    {pr.requested_reviewers && pr.requested_reviewers.length > 0
+                        ? pr.requested_reviewers.join(", ")
+                        : "None"}
+                </div>
+
+            </div>
+
+            {/* Desktop and Tablet design */}
+            <div className="hidden lg:grid lg:grid-cols-[1fr_0.5fr_2fr_2fr] lg:gap-2">
                 <Text fw={700} size="xl">
                     <span className="px-2 py-1.5 rounded text-sm lg:text-lg text-white shadow-md" style={{ backgroundColor: "#805AD5"}}>
                         #{pr.number}
@@ -48,7 +89,7 @@ export default function PullRequestCard({ pr }: Props) {
                     </Text>
 
                     <div className="text-md lg:text-lg" style={{ color: "#2D3748"}}>
-                        Opened by: @{pr.author ?? "Unknown"} on {createdText}
+                        Opened by: @{pr.author ?? "Unknown"} . {createdText}
                     </div>
                     
                     <div className="text-md lg:text-lg" style={{ color: "#2D3748"}}>

--- a/client/components/OpenPRCard.tsx
+++ b/client/components/OpenPRCard.tsx
@@ -12,13 +12,13 @@ export default function PullRequestCard({ pr }: Props) {
     const actionIcon = () => {
         switch (pr.lastAction) {
             case "open":
-                return <FaRegCheckCircle className="inline text-green-500 mx-1" />;
+                return <FaRegCheckCircle className="inline text-green-500 mx-3 size-6" />;
             case "approved":
-                return <FaRegCheckCircle className="inline text-green-700 mx-1" />;
+                return <FaRegCheckCircle className="inline text-green-700 mx-3 size-6" />;
             case "commented":
-                return <FaRegCommentDots className="inline text-blue-500 mx-1" />;
+                return <FaRegCommentDots className="inline text-blue-500 mx-3 size-6" />;
             case "changes_requested":
-                return <FaRegEdit className="inline text-red-500 mx-1" />;
+                return <FaRegEdit className="inline text-red-500 mx-3 size-6" />;
             default:
                 return null;
         }
@@ -31,33 +31,37 @@ export default function PullRequestCard({ pr }: Props) {
 
     return (
         <Card padding="lg" radius={0} className="mb-4 border-t-2 border-gray-400">
-            <div className="flex flex-col md:flex-row md:justify-between md:items-center">
-                <div>
-                    <Text fw={800} size="xl">
-                        <span className="bg-gray-200 px-2 py-1 rounded text-sm">
-                            #{pr.number}
-                        </span>
-                        {actionIcon()}
-                        <a href={pr.url} target="_blank" rel="noopener noreferrer" className="text-blue-600 hover:underline">
+            <div className="flex flex-col lg:grid lg:grid-cols-[1fr_0.5fr_2fr_2fr] lg:gap-2">
+                <Text fw={700} size="xl">
+                    <span className="px-2 py-1.5 rounded text-sm lg:text-lg text-white shadow-md" style={{ backgroundColor: "#805AD5"}}>
+                        #{pr.number}
+                    </span>
+                </Text>
+
+                <div>{actionIcon()}</div>
+
+                <div className="lg:mx-auto text-left lg:max-w-lg">
+                    <Text fw={700}>
+                        <a href={pr.url} target="_blank" rel="noopener noreferrer" className="text-blue-600 hover:underline lg:text-2xl">
                             {pr.title}
                         </a>
                     </Text>
 
-                    <Text size="md" c="dimmed">
+                    <div className="text-md lg:text-lg" style={{ color: "#2D3748"}}>
                         Opened by: @{pr.author ?? "Unknown"} on {createdText}
-                    </Text>
-
-                    <Text size="md" c="dimmed">
+                    </div>
+                    
+                    <div className="text-md lg:text-lg" style={{ color: "#2D3748"}}>
                         Last Action: {pr.lastAction} ()
-                    </Text>
+                    </div>
                 </div>
 
-                <Text size="md" c="dimmed" className="mt-2 md:mt-0">
+                <div className="lg:justify-self-end" style={{ color: "#2D3748"}}>
                     Reviewers:{" "}
                     {pr.requested_reviewers && pr.requested_reviewers.length > 0
                         ? pr.requested_reviewers.join(", ")
                         : "None"}
-                </Text>
+                </div>
             </div>
         </Card>
     );


### PR DESCRIPTION
## Description

- **page.tsx**
  - Display up to 3 PR cards per page.
  - Added forward and back buttons to navigate between pages.
  - Implemented pagination logic using local state.

- **OpenPRCard.tsx**
  - Updated card styling to match wireframe.
  - Display PR number, action icon, title, author, last action, and reviewers.
  - Responsive layout: desktop shows 4 columns; mobile stacks elements into 3 rows.
  
  
  
<img width="786" height="942" alt="Screenshot 2025-09-28 at 11 23 32 PM" src="https://github.com/user-attachments/assets/0ec6703d-91f9-490d-9fec-92ec58eace7c" />

