### PR TITLE
Refactor Open PR page: separate form & add Pagination with Jotai

### DIFF
--- a/client/atoms/prAtoms.ts
+++ b/client/atoms/prAtoms.ts
@@ -1,0 +1,19 @@
+import { atom } from "jotai";
+import type { PullRequest } from "@/types/pr";
+
+// Common repo info
+export const ownerAtom = atom("chingu-voyages");
+export const repoAtom = atom("V57-tier3-team-39");
+export const tokenAtom = atom("");
+
+// Open / Closed PR state
+export const openPRsAtom = atom<PullRequest[]>([]);
+export const closedPRsAtom = atom<PullRequest[]>([]);
+
+// page number
+export const openPageAtom = atom(1);
+export const closedPageAtom = atom(1);
+
+// erroe state
+export const openErrorAtom = atom("");
+export const closedErrorAtom = atom("");


### PR DESCRIPTION
### What changed
- Separated repository settings form into `RepoSettingsForm` component
- Added `Pagination` component using Jotai atoms
- Updated `OpenPRsPage` to use paginated PRs from atom state
- Fetch PRs now supports owner/repo/token from form inputs
- Minor UI adjustments for better readability

### Why
- To improve code reusability and maintainability
- To allow consistent pagination logic for both Open and Closed PR pages
