### PR TITLE
Update styling issue on Header, homepage, and long PR titles 

### DIFF
--- a/client/app/closed-prs/page.tsx
+++ b/client/app/closed-prs/page.tsx
@@ -24,7 +24,9 @@ export default function ClosedPRsPage() {
   const [repo] = useAtom(repoAtom);
   const [token] = useAtom(tokenAtom);
 
-  const [rateLimitRemaining, setRateLimitRemaining] = useState<number | null>(null);
+  const [rateLimitRemaining, setRateLimitRemaining] = useState<number | null>(
+    null
+  );
   const [limit, setLimit] = useState(5);
   const [loading, setLoading] = useState(false);
 
@@ -32,7 +34,7 @@ export default function ClosedPRsPage() {
   const paginatedPRs = prs.slice((page - 1) * PAGE_SIZE, page * PAGE_SIZE);
 
   const fetchPRs = async () => {
-    setLoading(true); 
+    setLoading(true);
     setError("");
     try {
       const tokenParam = token && token.trim() !== "" ? `&token=${token}` : "";
@@ -98,24 +100,24 @@ export default function ClosedPRsPage() {
           </div>
         )}
 
+        {paginatedPRs.length > 0 && (
+          <div className="pl-6">
+            <Text size="xl" fw={700}>
+              PR Display
+            </Text>
+          </div>
+        )}
+
         {/* PR display header */}
         <Box pos="relative">
           <LoadingOverlay
-                visible={loading}
-                overlayProps={{ radius: 'sm', blur: 2 }}
-                loaderProps={{ color: 'purple', type: 'bars' }}
+            visible={loading}
+            overlayProps={{ radius: "sm", blur: 2 }}
+            loaderProps={{ color: "purple", type: "bars" }}
           />
-          {paginatedPRs.length > 0 && (
-            <div className="pl-6">
-              <Text size="xl" fw={700}>
-                PR Display
-              </Text>
-            </div>
-          )}
-
           {/* If PR not found */}
           {paginatedPRs.length === 0 && !error ? (
-            <div 
+            <div
               className="text-gray-600 text-2xl text-center"
               role="status"
               aria-live="polite"
@@ -124,7 +126,9 @@ export default function ClosedPRsPage() {
             </div>
           ) : (
             // Display each PR
-            paginatedPRs.map((pr) => <PullRequestCard key={pr.number} pr={pr} />)
+            paginatedPRs.map((pr) => (
+              <PullRequestCard key={pr.number} pr={pr} />
+            ))
           )}
         </Box>
       </div>

--- a/client/app/page.tsx
+++ b/client/app/page.tsx
@@ -8,24 +8,25 @@ import {
 } from "@tabler/icons-react";
 import { FaRegHandshake, FaShieldHalved, FaEye } from "react-icons/fa6";
 import { FaHistory, FaRegStar } from "react-icons/fa";
+import { useRouter } from "next/navigation";
 
 export default function Home() {
-  const handleOpenPRPage: () => void = () => {
-    console.log("Open PR page");
+  const router = useRouter();
+
+  const handleOpenPRPage = () => {
+    router.push("/open-prs");
   };
 
   return (
-    <main className="text-center max-w-[1280] mx-auto">
-      <div className="bg-[#F0E7FF]">
+    <div className="bg-[#F0E7FF]">
+      <div className="max-w-[1280px] mx-auto">
         <div
-          className="text-white min-h-[884px] pt-[128px] px-[36px]"
+          className="text-white min-h-[884px] pt-[128px] px-[36px] bg-cover bg-center w-full"
           style={{
             backgroundImage: "url('/images/background.jpg')",
-            backgroundSize: "cover",
-            backgroundPosition: "center",
           }}
         >
-          <div className="flex-col justify-center items-center text-center max-w-[736px] mx-auto">
+          <div className="flex flex-col justify-center items-center text-center max-w-[736px] mx-auto">
             <h1 className="text-4xl font-bold ">
               Track Pull Requests Like Never Before!
             </h1>
@@ -127,8 +128,8 @@ export default function Home() {
                 Team Collaboration
               </h2>
               <p>
-                See who&#39; reviewing what and track team member contributions at
-                a glance
+                See who&#39; reviewing what and track team member contributions
+                at a glance
               </p>
             </Card>
           </div>
@@ -196,8 +197,9 @@ export default function Home() {
                 Ready to Streamline Your PR Process?
               </h2>
               <p>
-                Start tracking your team&#39;s pull requests today. No installation
-                required - just enter your repository details and go!
+                Start tracking your team&#39;s pull requests today. No
+                installation required - just enter your repository details and
+                go!
               </p>
               <div className="flex justify-center items-center mt-4">
                 <Button
@@ -215,6 +217,6 @@ export default function Home() {
           </div>
         </div>
       </div>
-    </main>
+    </div>
   );
 }

--- a/client/components/Footer.tsx
+++ b/client/components/Footer.tsx
@@ -15,7 +15,7 @@ const Footer = () => {
         </Link>
       </div>
       <div>
-        <Link target="_blank" href="/credits">
+        <Link href="/credits">
           <p>Credits</p>
         </Link>
       </div>

--- a/client/components/Header.tsx
+++ b/client/components/Header.tsx
@@ -33,7 +33,7 @@ const Header: React.FC = () => {
             </Link>
           </div>
 
-          <Link href="/">
+          <Link href="/" className="block [@media(max-width:490px)]:hidden">
             <h1 className="font-bold text-xl">PRTrackr</h1>
           </Link>
         </div>

--- a/client/components/PullRequestCard.tsx
+++ b/client/components/PullRequestCard.tsx
@@ -69,7 +69,7 @@ export default function PullRequestCard({ pr }: Props) {
               href={pr.url}
               target="_blank"
               rel="noopener noreferrer"
-              className="text-blue-600 hover:underline block truncate"
+              className="text-blue-600 hover:underline block overflow-hidden whitespace-nowrap text-ellipsis max-w-[50vw] sm:max-w-[70vw]"
             >
               {pr.title}
             </a>


### PR DESCRIPTION
- Hide the app title for very small screen size 
<img width="409" height="72" alt="image" src="https://github.com/user-attachments/assets/6825fa73-8b96-4a51-ad7f-f3ee033d6fd6" />

- Show ellipsis for long PR title 
<img width="340" height="393" alt="image" src="https://github.com/user-attachments/assets/57abc5f5-d728-49e9-857d-30edc449b266" />

- Add back the logic for the "handleOpenPRPage" and change the image back to full width size  
<img width="961" height="783" alt="image" src="https://github.com/user-attachments/assets/b5b7c376-8167-4dc0-afad-aed4098f166d" />



